### PR TITLE
Implement Hive Metastore schema loader

### DIFF
--- a/icebergc_fdw/Makefile
+++ b/icebergc_fdw/Makefile
@@ -1,6 +1,9 @@
 EXTENSION = icebergc_fdw
 MODULE_big = icebergc_fdw
-OBJS = icebergc_fdw.o
+OBJS = icebergc_fdw.o icebergc_hms.o
+
+PG_CPPFLAGS += -std=c++11
+SHLIB_LINK += -lthrift
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/icebergc_fdw/icebergc_fdw.c
+++ b/icebergc_fdw/icebergc_fdw.c
@@ -10,6 +10,7 @@
 #include "access/htup_details.h"
 #include "executor/executor.h"
 #include "utils/rel.h"
+#include "icebergc_hms.h"
 
 PG_MODULE_MAGIC;
 
@@ -101,6 +102,22 @@ icebergcBeginForeignScan(ForeignScanState *node, int eflags)
         icebergcGetOptions(RelationGetRelid(rel), table->serverid);
 
     node->fdw_state = (void *) opts;
+
+    /* Example: load schema from Hive Metastore */
+    int col_count = 0;
+    PGColInfo *cols = load_iceberg_table_schema("sample_db",
+                                                "sample_namespace",
+                                                "sample_table",
+                                                &col_count);
+    if (cols)
+    {
+        for (int i = 0; i < col_count; i++)
+        {
+            pfree(cols[i].name);
+            pfree(cols[i].type);
+        }
+        pfree(cols);
+    }
 }
 
 static TupleTableSlot *

--- a/icebergc_fdw/icebergc_hms.cpp
+++ b/icebergc_fdw/icebergc_hms.cpp
@@ -1,0 +1,59 @@
+#include "postgres.h"
+
+extern "C" {
+#include "utils/palloc.h"
+}
+
+#include <thrift/transport/TSocket.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include "hive_metastore_types.h"
+#include "hive_metastore_client.h"
+
+using namespace apache::thrift;
+using namespace apache::thrift::protocol;
+using namespace apache::thrift::transport;
+using namespace Apache::Hadoop::Hive;
+
+typedef struct PGColInfo
+{
+    char *name;
+    char *type;
+    bool nullable;
+} PGColInfo;
+
+PGColInfo *
+load_iceberg_table_schema(const char *db_name,
+                          const char *namespace_name,
+                          const char *table_name,
+                          int *out_len)
+{
+    std::shared_ptr<TSocket> socket(new TSocket("localhost", 9083));
+    std::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
+    std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+    ThriftHiveMetastoreClient client(protocol);
+
+    transport->open();
+    Table tbl;
+    client.get_table(tbl, db_name, namespace_name, table_name);
+    transport->close();
+
+    size_t cols = tbl.sd.cols.size();
+    PGColInfo *result = (PGColInfo *) palloc0(sizeof(PGColInfo) * cols);
+
+    for (size_t i = 0; i < cols; ++i)
+    {
+        const FieldSchema &f = tbl.sd.cols[i];
+        result[i].name = pstrdup(f.name.c_str());
+        result[i].type = pstrdup(f.type.c_str());
+        if (f.__isset.nullable)
+            result[i].nullable = f.nullable;
+        else
+            result[i].nullable = true;
+    }
+
+    if (out_len)
+        *out_len = cols;
+
+    return result;
+}

--- a/icebergc_fdw/icebergc_hms.h
+++ b/icebergc_fdw/icebergc_hms.h
@@ -1,0 +1,18 @@
+#ifndef ICEBERGC_HMS_H
+#define ICEBERGC_HMS_H
+
+#include "postgres.h"
+
+typedef struct PGColInfo
+{
+    char *name;
+    char *type;
+    bool nullable;
+} PGColInfo;
+
+PGColInfo *load_iceberg_table_schema(const char *db_name,
+                                     const char *namespace_name,
+                                     const char *table_name,
+                                     int *out_len);
+
+#endif /* ICEBERGC_HMS_H */


### PR DESCRIPTION
## Summary
- add C++ helper to load Hive table schema via Thrift
- expose PGColInfo struct and loader function
- call the loader in the FDW begin scan
- update Makefile to build the new code and link with libthrift

## Testing
- `make -C icebergc_fdw` *(fails: pgxs.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cc93a29308320bdc9679506909c00