### PR TITLE
Implement Parquet scan state and foreign scan callbacks

### DIFF
--- a/icebergc_fdw/parquet_utils.h
+++ b/icebergc_fdw/parquet_utils.h
@@ -1,6 +1,7 @@
 #ifndef PARQUET_UTILS_H
 #define PARQUET_UTILS_H
 
+#ifdef __cplusplus
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -25,4 +26,20 @@ std::vector<RowTuple> parse_parquet_buffer(const uint8_t *data,
                                            size_t length,
                                            size_t max_rows);
 
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+typedef struct ParquetReader ParquetReader;
+
+ParquetReader *parquet_reader_open(const char *path);
+bool parquet_reader_next(ParquetReader *reader, char **values, int ncols);
+void parquet_reader_close(ParquetReader *reader);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // PARQUET_UTILS_H
+


### PR DESCRIPTION
## Summary
- manage Parquet reader and row buffer in scan state
- implement Begin/Iterate/End foreign scan callbacks
- expose ParquetReader C++ helper with open/next/close

## Testing
- `make` (fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_689075b2cec083209c7b99f231736bd9